### PR TITLE
Changes to be committed:

### DIFF
--- a/config/framefetcher-params.json
+++ b/config/framefetcher-params.json
@@ -1,5 +1,5 @@
 {
-    "s3_pre_signed_url_expiry" : 2419200,
+    "s3_pre_signed_url_expiry" : 86400,
 
     "ddb_table" : "EnrichedFrame",
     "ddb_gsi_name" : "processed_year_month-processed_timestamp-index",

--- a/lambda/framefetcher/framefetcher.py
+++ b/lambda/framefetcher/framefetcher.py
@@ -12,6 +12,7 @@ import time
 import json
 import decimal
 from datetime import timedelta
+from botocore.client import Config
 
 
 class DecimalEncoder(json.JSONEncoder):
@@ -44,7 +45,7 @@ def fetch_frames(event, context):
 
     #Initialize clients
     dynamodb = boto3.resource('dynamodb')
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client('s3', config=Config(signature_version='s3v4'))
     
     #Load config
     config = load_config()


### PR DESCRIPTION
*Issue #, if available:*  58

*Description of changes:*. 
There were two files that were modified to ensure that the proper SigV4 S3 presigned urls can be generated.

modified:   config/framefetcher-params.json
	Reduced default URL expiration period to comply w/ SigV4 standards
modified:   lambda/framefetcher/framefetcher.py
	Added botoclient Config library
 	Modified s3 client initialization to use SigV4 signature

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
